### PR TITLE
Add RET2 YAML and index.md with RET2 details

### DIFF
--- a/index.md
+++ b/index.md
@@ -22,6 +22,7 @@ Second, we aim to empower training providers by offering them increased visibili
 | [Sektor7](https://institute.sektor7.net/) | RT🔴, PT🪓, MD🤖 | 6 | 🟨 Value | Malware Development, Red Teaming, Persistence, Privilege Escalation | - |
 | [TryHackMe](https://tryhackme.com/) | PT🪓, VR🧨, DF🔍, TH🏹 | 500+ | 🟩 Budget | - | - |
 | [Xintra](https://training.xintra.org/) | PT🪓, DF🔍, RE🔬 | 2 | 🟧 Premium | Azure, Cloud, iOS, Reverse Engineering, ARM | - | 
+| [RET2](https://wargames.ret2.systems/) | VR🧨, RE🔬 | 2 | 🟧 Premium | Vulnerability Research, Reverse Engineering | [YAML](./trainings/RET2.yml) |
 
 # Categories
 

--- a/trainings/RET2.yml
+++ b/trainings/RET2.yml
@@ -1,0 +1,15 @@
+provider: RET2
+website: https://wargames.ret2.systems/
+price-category: Premium
+previews-available: true
+access-period: 3 months
+discount-bulk-purchase: true
+trainings:
+    - title: RET2 WarGames Browser-Based Training Platform
+      short-description: An interactive, browser-based InfoSec training platform modeling real-world tools and workflows.
+      description: |
+       RET2 WarGames provides a comprehensive, browser-based training platform for InfoSec education. It eliminates the need for setup or specialized software, 
+       fitting entirely within a single browser tab. The platform faithfully simulates industry-standard tools, focusing on low-level system research including 
+       C-based vulnerabilities and writing successful exploits. Lab challenges offer real-time feedback and powerful introspection collects detailed analytics. 
+       Learning is paced and broken down into manageable chunks, with gamified checkpoints to encourage active learning. 
+      tags: Vulnerability Research, Reverse Engineering


### PR DESCRIPTION
Created RET2.yaml under the trainings directory. This file contains detailed information about RET2's WarGames Browser-Based Training Platform, including pricing, access period, description, tags, and other necessary details.

Updated index.md to reference the new RET2.yaml file. This ensures that the new provider's information is accessible from the repository's main page.

Including RET2 and its WarGames training platform adds more diversity and options to our repository, offering a unique, browser-based, and comprehensive InfoSec education platform for interested learners.

Please review these changes and let me know if any adjustments are required. 

Looking forward to your feedback.